### PR TITLE
fix(findOrCreate): warn and handle unknown attributes in defaults

### DIFF
--- a/lib/model.js
+++ b/lib/model.js
@@ -2082,6 +2082,15 @@ class Model {
 
     options = _.assign({}, options);
 
+    if (options.defaults) {
+      const defaults = Object.keys(options.defaults);
+      const unknownDefaults = defaults.filter(name => !this.rawAttributes[name]);
+
+      if (unknownDefaults.length) {
+        Utils.warn(`Unknown attributes (${unknownDefaults}) passed to defaults option of findOrCreate`);
+      }
+    }
+
     if (options.transaction === undefined && this.sequelize.constructor._cls) {
       const t = this.sequelize.constructor._cls.get('transaction');
       if (t) {
@@ -2122,7 +2131,9 @@ class Model {
         const flattenedWhere = Utils.flattenObjectDeep(options.where);
         const flattenedWhereKeys = _.map(_.keys(flattenedWhere), name => _.last(_.split(name, '.')));
         const whereFields = flattenedWhereKeys.map(name => _.get(this.rawAttributes, `${name}.field`, name));
-        const defaultFields = options.defaults && Object.keys(options.defaults).map(name => this.rawAttributes[name].field || name);
+        const defaultFields = options.defaults && Object.keys(options.defaults)
+          .filter(name => this.rawAttributes[name])
+          .map(name => this.rawAttributes[name].field || name);
 
         if (defaultFields) {
           if (!_.intersection(Object.keys(err.fields), whereFields).length && _.intersection(Object.keys(err.fields), defaultFields).length) {

--- a/test/integration/model/create.test.js
+++ b/test/integration/model/create.test.js
@@ -104,6 +104,36 @@ describe(Support.getTestDialectTeaser('Model'), () => {
       });
     });
 
+    it('should error correctly when defaults contain a unique key and a non-existent field', function() {
+      const User = this.sequelize.define('user', {
+        objectId: {
+          type: DataTypes.STRING,
+          unique: true
+        },
+        username: {
+          type: DataTypes.STRING,
+          unique: true
+        }
+      });
+
+      return User.sync({force: true}).then(() => {
+        return User.create({
+          username: 'gottlieb'
+        });
+      }).then(() => {
+        return expect(User.findOrCreate({
+          where: {
+            objectId: 'asdasdasd'
+          },
+          defaults: {
+            username: 'gottlieb',
+            foo: 'bar', // field that's not a defined attribute
+            bar: 121
+          }
+        })).to.eventually.be.rejectedWith(Sequelize.UniqueConstraintError);
+      });
+    });
+
     it('should error correctly when defaults contain a unique key and the where clause is complex', function() {
       const User = this.sequelize.define('user', {
         objectId: {


### PR DESCRIPTION
Cherry picks this commit https://github.com/sequelize/sequelize/commit/b505723927305960003dae2a8b64e1f291a5f927 to fix an issue in `findOrCreate`.

See https://soradotco.slack.com/archives/C01V1EQTWAK/p1633607718183000 for more context